### PR TITLE
Enhancing support for projects utilizing worker threads

### DIFF
--- a/climem.js
+++ b/climem.js
@@ -12,6 +12,7 @@ const pump = require('pump')
 const writer = require('flush-write-stream')
 const blessed = require('blessed')
 const contrib = require('blessed-contrib')
+const { parentPort } = require('worker_threads')
 
 function Monitor () {
   Readable.call(this)

--- a/climem.js
+++ b/climem.js
@@ -169,8 +169,16 @@ function cli () {
   }
 }
 
-if (require.main === module) {
-  cli()
-} else {
-  monitor()
+function startClimem () {
+  if (parentPort) {
+    return
+  }
+
+  if (require.main === module) {
+    cli()
+  } else {
+    monitor()
+  }
 }
+
+startClimem()


### PR DESCRIPTION
Hello,

I've submitted this pull request because I encountered some issues while using climem in Node.js projects that employ worker threads. In this particular situation, every worker I create attempts to open a new climem port on the same address as the main thread, resulting in an "address already in use" error.

To address this problem, I've introduced a conditional check before initiating the climem script. This check ensures that the script only runs when executed on the main thread. If it's running on a worker thread, the script will be skipped altogether.